### PR TITLE
Split main page into multiple subpages + clickable references

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the files required for a proper LaTeX
 submission of an MSCS thesis CSU Channel Islands. Follow the
 instructions in:
 ```
-media/EU MS Thesis Submission Procedure.pdf
+eu-ms-thesis-submission-procedure.pdf
 ```
 for the technicalities of a submission to EU. See the Computer Science
 Web site for general information about MSCS:

--- a/pages/approvalpage.tex
+++ b/pages/approvalpage.tex
@@ -1,0 +1,27 @@
+\begin{center}
+{\large \bfseries APPROVED FOR MS IN COMPUTER SCIENCE \par}
+
+\vspace{1.5 cm}
+
+\hrulefill\\
+{\large \bfseries Advisor: \advisorname \hfill Date \par}
+
+\vspace{1.5 cm}
+
+\hrulefill\\
+{\large \bfseries Name \hfill Date \par}
+
+\vspace{1.5 cm}
+
+\hrulefill\\
+{\large \bfseries Name \hfill Date \par}
+
+\vspace{3 cm}
+
+{\large \bfseries APPROVED FOR THE UNIVERITY \par}
+
+\vspace{1.5 cm}
+
+\hrulefill\\
+{\large \bfseries Name \hfill Date \par}
+\end{center}

--- a/pages/background.tex
+++ b/pages/background.tex
@@ -1,0 +1,2 @@
+
+Your work goes here

--- a/pages/conclusion.tex
+++ b/pages/conclusion.tex
@@ -1,0 +1,1 @@
+Your work goes here

--- a/pages/copyrightpage.tex
+++ b/pages/copyrightpage.tex
@@ -1,0 +1,7 @@
+\null
+\vfill
+\begin{flushleft}
+\copyright\; Year\\
+\studentname\\
+ALL RIGHTS RESERVED
+\end{flushleft}

--- a/pages/frontpage.tex
+++ b/pages/frontpage.tex
@@ -1,0 +1,27 @@
+\begin{titlepage}
+\pagenumbering{gobble}
+\begin{center}
+{\Large \bfseries \thesistitle \par}
+
+\vspace{2 cm}
+\baselineskip = 2\baselineskip
+A Thesis Presented to \\
+The Faculty of the Computer Science Department\\
+California State University Channel Islands
+
+\vspace{1 cm}
+
+In (Partial) Fulfillment\\
+of the Requirements for the Degree\\
+Masters of Science in Computer Science\\
+
+\vspace{1 cm }
+
+\vfill
+
+by \\
+\studentname\\
+Advisor: \advisorname\\
+Month Year
+\end{center}
+\end{titlepage}

--- a/pages/introduction.tex
+++ b/pages/introduction.tex
@@ -1,0 +1,11 @@
+An example of dividing pages into subfiles.\\
+An example citation: \cite{graves-1995}.\\
+An example reference: \autoref{fig:ci-logo} (Notice references and citations are clickable!)
+
+% When including grapics, make sure the directory is relative to root .tex document, not the current .tex file
+\begin{figure}[H]
+	\centering
+	\includegraphics[width=0.7\linewidth]{media/ci-logo}
+	\caption{This is an example graphic}
+	\label{fig:ci-logo}
+\end{figure}

--- a/preamble.tex
+++ b/preamble.tex
@@ -18,9 +18,22 @@
 \usepackage{algorithm}
 \usepackage[all]{xy}
 \usepackage{pdfpages}
+\usepackage{titlesec}
+
+% Ensures a new section is on its own page. Must be done before hyperref is loaded
+\newcommand{\sectionbreak}{\clearpage}
+
+% Clickable references
+\usepackage[hidelinks]{hyperref}
+
+% Ensures graphic is in view after clicking on a reference to see it
+\usepackage[all]{hypcap} 
+
+
 % \doublespacing
 \renewcommand{\topfraction}{0.9}	% max fraction of floats at top
 \renewcommand{\bottomfraction}{0.8}	% max fraction of floats at bottom
+
 %   Parameters for TEXT pages (not float pages):
 \setcounter{topnumber}{2}
 \setcounter{bottomnumber}{2}
@@ -28,8 +41,10 @@
 \setcounter{dbltopnumber}{2}    % for 2-column pages
 \renewcommand{\dbltopfraction}{0.9}	% fit big float above 2-col. text
 \renewcommand{\textfraction}{0.07}	% allow minimal text w. figs
+
 %   Parameters for FLOAT pages (not text pages):
-    \renewcommand{\floatpagefraction}{0.7}	% require fuller float pages
+\renewcommand{\floatpagefraction}{0.7}	% require fuller float pages
+    
 % N.B.: floatpagefraction MUST be less than topfraction !!
 \renewcommand{\dblfloatpagefraction}{0.7}	% require fuller float pages
 

--- a/project-info.tex
+++ b/project-info.tex
@@ -1,4 +1,10 @@
+% Replace "Thesis Title", "Student name" etc. below with the correct values
+% These values will then be automatically added wherever necessary in thesis-template.tex and defence-announcement.tex
 
 \newcommand{\thesistitle}{Thesis title}
 \newcommand{\studentname}{Student name}
 \newcommand{\advisorname}{Advisor name}
+
+% Custom commands for other often used strings (\pythonversion, \submissionyear etc.) can be added
+% below using the following template
+% \newcommand{\<commandname>}{<commandvalue>}

--- a/thesis-template.tex
+++ b/thesis-template.tex
@@ -1,4 +1,3 @@
-
 \documentclass[12pt]{article}
 %\topmargin=-0.5in
 %\textheight=9in
@@ -7,91 +6,32 @@
 %\setlength{\textwidth}{6.5in}
 
 \input{project-info}
-
 \input{preamble}
-
-\begin{document}
-
-\begin{titlepage}
-\pagenumbering{gobble}
-\begin{center}
-{\Large \bfseries \thesistitle \par}
-
-\vspace{2 cm}
-\baselineskip = 2\baselineskip
-A Thesis Presented to \\
-The Faculty of the Computer Science Department\\
-California State University Channel Islands
-
-\vspace{1 cm}
-
-In (Partial) Fulfillment\\
-of the Requirements for the Degree\\
-Masters of Science in Computer Science\\
-
-\vspace{1 cm }
-
-\vfill
-
-by \\
-\studentname\\
-Advisor: \advisorname\\
-Month Year
-\end{center}
-\end{titlepage}
-\baselineskip = \baselineskip
-
-\newpage
-\null
-\vfill
-\begin{flushleft}
-\copyright\; Year\\
-\studentname\\
-ALL RIGHTS RESERVED
-\end{flushleft}
-\newpage
-
-\begin{center}
-{\large \bfseries APPROVED FOR MS IN COMPUTER SCIENCE \par}
-
-\vspace{1.5 cm}
-
-\hrulefill\\
-{\large \bfseries Advisor: \advisorname \hfill Date \par}
-
-\vspace{1.5 cm}
-
-\hrulefill\\
-{\large \bfseries Name \hfill Date \par}
-
-\vspace{1.5 cm}
-
-\hrulefill\\
-{\large \bfseries Name \hfill Date \par}
-
-\vspace{3 cm}
-
-{\large \bfseries APPROVED FOR THE UNIVERITY \par}
-
-\vspace{1.5 cm}
-
-\hrulefill\\
-{\large \bfseries Name \hfill Date \par}
-\end{center}
-
-\newpage
-
-\includepdf{media/distribution-license.pdf}
-
-\newpage
 
 \title{\thesistitle} 
 \author{\studentname}
-
 \date{\today}
+
+\begin{document}
+
+\input{pages/frontpage}
+\baselineskip = \baselineskip
+\newpage
+
+\input{pages/copyrightpage}
+\newpage
+
+\input{pages/approvalpage}
+\newpage
+
+\includepdf{media/distribution-license.pdf}
+\newpage
+
+
 \maketitle
 
 \begin{abstract}
+	Abstract goes here
 \end{abstract}
 
 \newpage
@@ -108,24 +48,21 @@ ALL RIGHTS RESERVED
 
 \section{Introduction}
 \label{sect-intro}
+\input{pages/introduction}
 
-An example citation: \cite{graves-1995}
-
-\newpage
 \section{Background}
 \label{sect-background}
+\input{pages/background}
 
-Your work goes here
-
-\newpage
 \section{Conclusion and future work}
 \label{sect-conclusion}
+\input{pages/conclusion}
 
-Your work goes here
-
-\newpage
+\cleardoublepage
+\phantomsection
 \bibliographystyle{plain}
 \bibliography{references}
+\addcontentsline{toc}{section}{References}
 
 \end{document}
 


### PR DESCRIPTION
**Split the main page into multiple sub-pages**
For someone without a latex-aware editor, it may be a hindrance to have it split up into so many files. But with an editor like TeXstudio or VSCode with extensions, it improves the workflow as you're only looking at the text that's relevant for what you're editing.

**Improved referencing**
Added the hyperref package, enabling click to navigate in pdf.
Added 'References' to the table of contents

**Added comments to project-info.tex**
As you mentioned, a few comments to make it easier for the student to add more commands and edit the existing ones.

**Start of new sections placed on separate page**
Each new section is now automatically placed on its own page.

