### PR TITLE
Change bib style from 'plain' to 'unsrt'

### DIFF
--- a/thesis-template.tex
+++ b/thesis-template.tex
@@ -70,7 +70,8 @@ Your work goes here
 
 \cleardoublepage
 \phantomsection
-\bibliographystyle{unsrt}
+\bibliographystyle{unsrt} % lists references based on order in text
+%\bibliographystyle{plain} % lists references based on bibtex order
 \bibliography{references}
 \addcontentsline{toc}{section}{References}
 

--- a/thesis-template.tex
+++ b/thesis-template.tex
@@ -70,8 +70,10 @@ Your work goes here
 
 \cleardoublepage
 \phantomsection
-\bibliographystyle{unsrt} % lists references based on order in text
-%\bibliographystyle{plain} % lists references based on bibtex order
+% 'unsrt' lists references based on order in text
+\bibliographystyle{unsrt}
+% 'plain' lists references based on bibtex order
+%\bibliographystyle{plain} 
 \bibliography{references}
 \addcontentsline{toc}{section}{References}
 

--- a/thesis-template.tex
+++ b/thesis-template.tex
@@ -70,7 +70,7 @@ Your work goes here
 
 \cleardoublepage
 \phantomsection
-\bibliographystyle{plain}
+\bibliographystyle{unsrt}
 \bibliography{references}
 \addcontentsline{toc}{section}{References}
 


### PR DESCRIPTION
The 'plain' style will number references based on bibtex order. It is desirable to order the references based on it's appearance in the document. First ref is [1], etc.
The unsorted 'unsrt' style will accomplish this.