### PR TITLE
Frontpage double formatting fix

### DIFF
--- a/pages/frontpage.tex
+++ b/pages/frontpage.tex
@@ -1,6 +1,7 @@
 \begin{titlepage}
 \pagenumbering{gobble}
 \begin{center}
+\begin{singlespacing}
 %------------ university endorsement-------
 \includegraphics[width=0.60\textwidth]{media/correctlogo.jpg}~\\
 
@@ -47,5 +48,6 @@ Dr.~Abc \textsc{Xyz}
 %Advisor: \advisorname\\
 Month Year\\
 \HRule \\[1.0cm]
+\end{singlespacing}
 \end{center}
 \end{titlepage}


### PR DESCRIPTION
When the double-spacing flag in the preamble is enabled it causes the title page to double space and become unformatted. This fix forces the title page block to remain single-spaced.